### PR TITLE
OEL-337: Drupal 9 update.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.2",
-        "twig/twig": "^1.34 || ^2.14"
+        "twig/twig": "^1.38 || ^2.7"
     },
     "require-dev": {
         "cweagans/composer-patches": "~1.6",

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.2",
-        "twig/twig": "^1.34"
+        "twig/twig": "^1.34 || ^2.14"
     },
     "require-dev": {
         "cweagans/composer-patches": "~1.6",
-        "openeuropa/code-review": "~1.0.0-beta2",
-        "phpunit/phpunit": "~5.5||~6.0"
+        "openeuropa/code-review": "^1.6",
+        "phpunit/phpunit": "^6.5 || ^7 || ^8 || ^9"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,9 +8,9 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+         cacheResult="false">
   <testsuites>
-    <testsuite>
+    <testsuite name="ECL Twig Loader">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>

--- a/src/Loader/EuropaComponentLibraryLoader.php
+++ b/src/Loader/EuropaComponentLibraryLoader.php
@@ -7,7 +7,7 @@ namespace OpenEuropa\Twig\Loader;
  *
  * @package OpenEuropa\Twig\Loader
  */
-class EuropaComponentLibraryLoader extends \Twig_Loader_Filesystem
+class EuropaComponentLibraryLoader extends \Twig\Loader\FilesystemLoader
 {
 
     /**
@@ -66,7 +66,7 @@ class EuropaComponentLibraryLoader extends \Twig_Loader_Filesystem
     /**
      * {@inheritdoc}
      */
-    protected function findTemplate($name)
+    protected function findTemplate($name, $throw = true)
     {
         list($namespace, $componentName) = $this->parseName($name);
 
@@ -132,5 +132,21 @@ class EuropaComponentLibraryLoader extends \Twig_Loader_Filesystem
     protected function isFullName($componentName)
     {
         return (bool) preg_match("/^{$this->prefix}(.*)\/{$this->templatePrefix}(.*){$this->extension}$/", $componentName);
+    }
+
+    protected function parseName($name, $default = self::MAIN_NAMESPACE): array
+    {
+        if (isset($name[0]) && '@' === $name[0]) {
+            if (false === $pos = strpos($name, '/')) {
+                throw new \Twig\Error\LoaderError(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
+            }
+
+            $namespace = substr($name, 1, $pos - 1);
+            $shortname = substr($name, $pos + 1);
+
+            return [$namespace, $shortname];
+        }
+
+        return [$default, $name];
     }
 }

--- a/src/Loader/EuropaComponentLibraryLoader.php
+++ b/src/Loader/EuropaComponentLibraryLoader.php
@@ -2,12 +2,15 @@
 
 namespace OpenEuropa\Twig\Loader;
 
+use Twig\Loader\FilesystemLoader;
+use Twig\Error\LoaderError;
+
 /**
  * Class EuropaComponentLibraryLoader.
  *
  * @package OpenEuropa\Twig\Loader
  */
-class EuropaComponentLibraryLoader extends \Twig\Loader\FilesystemLoader
+class EuropaComponentLibraryLoader extends FilesystemLoader
 {
 
     /**
@@ -134,11 +137,14 @@ class EuropaComponentLibraryLoader extends \Twig\Loader\FilesystemLoader
         return (bool) preg_match("/^{$this->prefix}(.*)\/{$this->templatePrefix}(.*){$this->extension}$/", $componentName);
     }
 
+    /**
+     * Copy of private function Twig\Loader\FilesystemLoader::parseName().
+     */
     protected function parseName($name, $default = self::MAIN_NAMESPACE): array
     {
         if (isset($name[0]) && '@' === $name[0]) {
             if (false === $pos = strpos($name, '/')) {
-                throw new \Twig\Error\LoaderError(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
+                throw new LoaderError(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
             }
 
             $namespace = substr($name, 1, $pos - 1);


### PR DESCRIPTION
## OPENEUROPA-337

### Description

Fixes to upgrade oe_theme to Drupal 9

### Change log

- Added:
- Changed: PHP 7.3 required and accept Twig 2.14. Some Twig updates.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```
