### PR TITLE
Fix LoaderError for templates outside registered namespaces.

### DIFF
--- a/src/Loader/EuropaComponentLibraryLoader.php
+++ b/src/Loader/EuropaComponentLibraryLoader.php
@@ -75,7 +75,7 @@ class EuropaComponentLibraryLoader extends FilesystemLoader
 
         // If namespace is not one of ours just move along, nothing to see here.
         if (!in_array($namespace, $this->namespaces)) {
-            return parent::findTemplate($name);
+            return parent::findTemplate($name, $throw);
         }
 
         // If component uses full name just use it, our job is done.


### PR DESCRIPTION
## Problem

  When using the loader in a ChainLoader context (e.g. Drupal), browsing pages that render templates not belonging to the loader's namespaces triggers:

> Twig\Error\LoaderError: There are no registered paths for namespace "__main__"

I ran into this on a Drupal site when accessing the media library grid page `/admin/content/media-grid` .

## Cause

In `findTemplate()`, when the namespace is not one of the registered ones, the `$throw` parameter is not forwarded to `parent::findTemplate()`. This causes the parent to throw instead of returning `false` when called from `exists()`.

## Fix

Forward `$throw` to the parent call on line 78.